### PR TITLE
ci: fix OSV scanner action ref (@v1 → @v2.3.5)

### DIFF
--- a/.github/workflows/weekly-scans.yml
+++ b/.github/workflows/weekly-scans.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: OSV scanner
         id: scan
-        uses: google/osv-scanner-action/osv-scanner-action@v1
+        uses: google/osv-scanner-action/osv-scanner-action@v2.3.5
         with:
           scan-args: |-
             --lockfile=pubspec.lock


### PR DESCRIPTION
## Summary

First manual run of `weekly-scans.yml` on master errored with:
`Unable to resolve action \`google/osv-scanner-action@v1\`, unable to find version \`v1\``.

The upstream repo only publishes `v2.3.x` tags. Pinning to `v2.3.5` (latest stable).

## Test Plan

- [ ] Merge → manually trigger Weekly Scans → OSV dep scan runs to completion (either green = no vulns, or opens a `security` issue if there are).