### PR TITLE
ci: use seconds-since-2025 for build numbers (fix release/prod collision)

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -10,8 +10,25 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Same scheme as release.yml: seconds since 2025-01-01 UTC. See comment
+  # there for rationale. This run's build number will always exceed any
+  # build number produced by the preceding release.yml run for the same
+  # tag, since production.yml fires after release.yml finishes.
+  compute-build-number:
+    name: Compute shared build number
+    runs-on: ubuntu-latest
+    outputs:
+      build: ${{ steps.calc.outputs.build }}
+    steps:
+      - id: calc
+        run: |
+          BUILD=$(( $(date -u +%s) - 1735689600 ))
+          echo "build=${BUILD}" >> "$GITHUB_OUTPUT"
+          echo "Build number for this run: ${BUILD}"
+
   deploy-ios-appstore:
     name: iOS → App Store
+    needs: compute-build-number
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,10 +42,11 @@ jobs:
           supabase-anon-key: ${{ secrets.SUPABASE_ANON_KEY }}
           maptiler-api-key: ${{ secrets.MAPTILER_API_KEY }}
 
-      - name: Stamp version (semver from tag + run_number build)
+      - name: Stamp version (semver from tag + shared build number)
+        env:
+          BUILD: ${{ needs.compute-build-number.outputs.build }}
         run: |
           SEMVER="${GITHUB_REF_NAME#v}"
-          BUILD=${{ github.run_number }}
           sed -i.bak "s/^version:.*/version: ${SEMVER}+${BUILD}/" pubspec.yaml
           echo "Stamped: $(grep '^version:' pubspec.yaml)"
 
@@ -64,6 +82,7 @@ jobs:
 
   deploy-android-production:
     name: Android → Play Production
+    needs: compute-build-number
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -82,10 +101,11 @@ jobs:
           supabase-anon-key: ${{ secrets.SUPABASE_ANON_KEY }}
           maptiler-api-key: ${{ secrets.MAPTILER_API_KEY }}
 
-      - name: Stamp version (semver from tag + run_number build)
+      - name: Stamp version (semver from tag + shared build number)
+        env:
+          BUILD: ${{ needs.compute-build-number.outputs.build }}
         run: |
           SEMVER="${GITHUB_REF_NAME#v}"
-          BUILD=${{ github.run_number }}
           sed -i.bak "s/^version:.*/version: ${SEMVER}+${BUILD}/" pubspec.yaml
           echo "Stamped: $(grep '^version:' pubspec.yaml)"
 
@@ -127,7 +147,7 @@ jobs:
 
   publish-release:
     name: Publish GitHub Release
-    needs: [deploy-ios-appstore, deploy-android-production]
+    needs: [compute-build-number, deploy-ios-appstore, deploy-android-production]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -145,7 +165,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.ref_name }}
-          BUILD: ${{ github.run_number }}
+          BUILD: ${{ needs.compute-build-number.outputs.build }}
         run: |
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release edit "$TAG" --draft=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,29 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Build number scheme: seconds since 2025-01-01 UTC. Gives a value that
+  # (a) is always strictly increasing across release.yml and production.yml
+  # runs because production always fires after release, (b) is identical
+  # for the iOS and Android jobs in the same workflow run (both read this
+  # job's output), and (c) fits int32 for Play's versionCode ceiling
+  # (headroom until ~2093). github.run_number can't be used here because
+  # each workflow has its own counter — release and production would
+  # collide on first tag push.
+  compute-build-number:
+    name: Compute shared build number
+    runs-on: ubuntu-latest
+    outputs:
+      build: ${{ steps.calc.outputs.build }}
+    steps:
+      - id: calc
+        run: |
+          BUILD=$(( $(date -u +%s) - 1735689600 ))
+          echo "build=${BUILD}" >> "$GITHUB_OUTPUT"
+          echo "Build number for this run: ${BUILD}"
+
   deploy-ios-testflight:
     name: iOS → TestFlight
+    needs: compute-build-number
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,10 +47,11 @@ jobs:
           supabase-anon-key: ${{ secrets.SUPABASE_ANON_KEY }}
           maptiler-api-key: ${{ secrets.MAPTILER_API_KEY }}
 
-      - name: Stamp version (semver from pubspec + run_number build)
+      - name: Stamp version (semver from pubspec + shared build number)
+        env:
+          BUILD: ${{ needs.compute-build-number.outputs.build }}
         run: |
           SEMVER=$(grep '^version:' pubspec.yaml | sed 's/version: //' | cut -d'+' -f1 | tr -d ' ')
-          BUILD=${{ github.run_number }}
           sed -i.bak "s/^version:.*/version: ${SEMVER}+${BUILD}/" pubspec.yaml
           echo "Stamped: $(grep '^version:' pubspec.yaml)"
 
@@ -58,6 +80,7 @@ jobs:
 
   deploy-android-internal:
     name: Android → Play Internal
+    needs: compute-build-number
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -76,10 +99,11 @@ jobs:
           supabase-anon-key: ${{ secrets.SUPABASE_ANON_KEY }}
           maptiler-api-key: ${{ secrets.MAPTILER_API_KEY }}
 
-      - name: Stamp version (semver from pubspec + run_number build)
+      - name: Stamp version (semver from pubspec + shared build number)
+        env:
+          BUILD: ${{ needs.compute-build-number.outputs.build }}
         run: |
           SEMVER=$(grep '^version:' pubspec.yaml | sed 's/version: //' | cut -d'+' -f1 | tr -d ' ')
-          BUILD=${{ github.run_number }}
           sed -i.bak "s/^version:.*/version: ${SEMVER}+${BUILD}/" pubspec.yaml
           echo "Stamped: $(grep '^version:' pubspec.yaml)"
 
@@ -114,7 +138,7 @@ jobs:
 
   create-draft-release:
     name: Create/update draft GitHub Release
-    needs: [deploy-ios-testflight, deploy-android-internal]
+    needs: [compute-build-number, deploy-ios-testflight, deploy-android-internal]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -131,7 +155,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.ver.outputs.tag }}
-          BUILD: ${{ github.run_number }}
+          BUILD: ${{ needs.compute-build-number.outputs.build }}
           SHA: ${{ github.sha }}
         run: |
           BODY="Testing in TestFlight (build ${BUILD}) and Play Internal (build ${BUILD}). Tag this commit \`${TAG}\` after beta verification to promote to production."

--- a/docs/GIT_FLOW.md
+++ b/docs/GIT_FLOW.md
@@ -201,5 +201,18 @@ Semantic versioning: `MAJOR.MINOR.PATCH`.
 - **PATCH**: bug fixes.
 
 Build number (the `+N` after the semver in `pubspec.yaml`) is overwritten
-by CI to `github.run_number`. Both stores require a strictly-increasing
-build number. Never manually reset it.
+at build time by CI — whatever you commit for `+N` is ignored. Both stores
+require strictly-increasing build numbers, so the scheme is:
+
+```
+build_number = seconds_since_2025_01_01_UTC
+```
+
+A `compute-build-number` job in each of `release.yml` and `production.yml`
+computes this value and passes it to all downstream jobs via job outputs,
+so iOS and Android in the same workflow run get the same build number. The
+seconds-since-epoch base ensures production.yml (which always fires after
+release.yml) produces a higher build number than the preceding release run
+for the same version — a plain `github.run_number` would not, because each
+workflow has its own counter. The value fits in int32 (Play's `versionCode`
+ceiling) with headroom until roughly 2093.


### PR DESCRIPTION
## Summary

`github.run_number` is **per-workflow**. On the first `v*.*.*` tag push, `release.yml` run #1 and `production.yml` run #1 would both produce build number `1`, and the second upload to each store would be rejected (build numbers must strictly increase).

Swapped to a `compute-build-number` job in each of `release.yml` and `production.yml` that emits `seconds_since_2025_01_01_UTC` and feeds it to all downstream jobs via job outputs.

Properties:
- Monotonic across `release.yml` and `production.yml` — production always fires after release, so its timestamp-based build number is always higher.
- Identical for iOS + Android within the same workflow run (both read the same job output).
- Fits int32 (Play's `versionCode` ceiling). Headroom until roughly 2093.

Also updated `docs/GIT_FLOW.md` Version Numbering section to document the scheme.

## Test Plan

- [ ] PR checks remain green (they don't exercise release/production, but they gate format/analyze/build).
- [ ] After merge: first real release (push `release/v0.3.6`) should show `0.3.6+<~41M>` on TestFlight and Play Internal.
- [ ] After tag push: App Store / Play Production build number must be > the TestFlight / Play Internal build number from the preceding release.yml run.