### PR TITLE
build(android): fix Play showing 0.2.0 by reading version from pubspec

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -32,8 +32,12 @@ android {
         applicationId = "com.ccwmap.app"
         minSdk = flutter.minSdkVersion  // Minimum Android 5.0 (Lollipop)
         targetSdk = 35  // Required for 2026 Play Store compliance
-        versionCode = 4
-        versionName = "0.2.0"
+        // Read from pubspec.yaml via the Flutter Gradle plugin so CI's
+        // stamp step (sed on pubspec) actually takes effect. Previously
+        // hardcoded to 0.2.0 / 4, which caused Play Internal to display
+        // 0.2.0 regardless of what pubspec said.
+        versionCode = flutter.versionCode
+        versionName = flutter.versionName
     }
 
     signingConfigs {


### PR DESCRIPTION
## Summary

`android/app/build.gradle.kts` had `versionCode = 4` and `versionName = \"0.2.0\"` hardcoded in `defaultConfig`. Our CI stamp step (`sed` on pubspec) had no effect because Gradle never looked at pubspec. Result: after the first `release/v0.3.6` run, TestFlight correctly showed 0.3.6 (iOS uses `\$(FLUTTER_BUILD_NAME)` / `\$(FLUTTER_BUILD_NUMBER)` placeholders in Info.plist) but Play Internal showed 0.2.0 / versionCode 4.

Switched both fields to the values the Flutter Gradle plugin exposes from pubspec:

```kotlin
versionCode = flutter.versionCode
versionName = flutter.versionName
```

This is the Flutter-standard wiring — it's what `flutter create` has always produced; the repo was inadvertently overriding it with literals.

## Test Plan

- [x] Local `flutter build appbundle --release` succeeds.
- [x] Extracted `AndroidManifest.xml` from the AAB shows `versionName=0.3.5` (from `pubspec.yaml: 0.3.5+18`) — previously the manifest contained `0.2.0`.
- [ ] After merge + next `release/*` push: Play Internal should display the correct `MAJOR.MINOR.PATCH`, and versionCode should match the pipeline's build-number stamp.

## Next-release note

The current Play Internal track has a release at versionCode `4`. Any subsequent Android upload must have versionCode > 4 or Play will reject it. Both the existing `github.run_number` scheme and PR #13's timestamp-based scheme produce values well above 4, so no action needed on our side.