### PR TITLE
docs(v0.4.0): add Terms page, rewrite data-deletion for in-app flow

### DIFF
--- a/docs/data-deletion.html
+++ b/docs/data-deletion.html
@@ -83,18 +83,18 @@
 <body>
     <h1>Account & Data Deletion</h1>
 
-    <p>This page explains how to request deletion of your CCW Map account and associated data.</p>
+    <p>This page explains how to delete your CCW Map account and associated data. You can do it yourself from inside the app, or request deletion by email as a fallback.</p>
 
     <hr>
 
     <div class="danger">
         <h3>⚠️ Important Notice</h3>
         <p><strong>Account deletion is permanent and irreversible.</strong></p>
-        <p>Once your account is deleted, you will NOT be able to:</p>
+        <p>Once your account is deleted:</p>
         <ul>
-            <li>Recover your email address or password</li>
-            <li>Access pins you created</li>
-            <li>Restore your account</li>
+            <li>You cannot recover your email address or password.</li>
+            <li>You cannot restore the account.</li>
+            <li>You will be signed out of all devices immediately.</li>
         </ul>
     </div>
 
@@ -102,7 +102,7 @@
 
     <h2>What Gets Deleted</h2>
 
-    <p>When you request account deletion, the following data will be permanently removed:</p>
+    <p>When your account is deleted, the following personal data is permanently removed from our servers:</p>
 
     <h3>1. Account Information</h3>
     <ul>
@@ -112,70 +112,78 @@
         <li>Session tokens</li>
     </ul>
 
-    <h3>2. User Content</h3>
+    <h3>2. Personal Records Tied to Your Account</h3>
     <ul>
-        <li>All pins you created (including coordinates, status, and metadata)</li>
-        <li>Pin modification history</li>
-        <li>Sync queue entries</li>
+        <li>Your Terms of Use acceptance record</li>
+        <li>Your blocklist (users you blocked, and other users' blocks targeting you)</li>
     </ul>
 
     <hr>
 
     <h2>What May Be Retained</h2>
 
-    <p>Some data may be retained for legal, security, or operational reasons:</p>
+    <p>Some data may be retained for legal, security, or operational reasons, or because it is community data that outlives any single account:</p>
 
     <ul>
-        <li><strong>Anonymous usage statistics</strong>: Aggregated, non-identifiable analytics data</li>
-        <li><strong>Legal compliance</strong>: Records required by law (fraud prevention, abuse reports)</li>
-        <li><strong>Backup archives</strong>: May take up to 90 days to fully purge from backup systems</li>
+        <li><strong>Pins you created</strong>: The pins stay on the map as community content, but the <em>creator link</em> is severed — the pin is no longer tied to your account. Any signed-in user can subsequently edit or remove these pins through normal crowd-sourced moderation. If you want specific pins gone, remove them <strong>before</strong> deleting your account.</li>
+        <li><strong>Reports you filed on other users' pins</strong>: The report is preserved for moderation continuity but the reporter link is cleared.</li>
+        <li><strong>Anonymous usage statistics</strong>: Aggregated, non-identifiable analytics data.</li>
+        <li><strong>Legal compliance</strong>: Records required by law (fraud prevention, abuse investigations).</li>
+        <li><strong>Backup archives</strong>: May take up to 90 days to fully purge from backup systems.</li>
     </ul>
 
     <hr>
 
-    <h2>How to Request Deletion</h2>
+    <h2>How to Delete Your Data</h2>
 
     <div class="info">
-        <h3>Option 1: Delete Individual Pins (Recommended)</h3>
+        <h3>Option 1: Delete Individual Pins</h3>
         <p>If you only want to remove specific pins:</p>
         <ol>
             <li>Open the CCW Map app</li>
-            <li>Tap on the pin you want to delete</li>
-            <li>Select "Delete Pin" in the pin dialog</li>
+            <li>Tap the pin you want to remove</li>
+            <li>Select <strong>Delete Pin</strong> in the pin dialog</li>
         </ol>
-        <p><strong>Note:</strong> This does NOT delete your account, only the selected pin.</p>
+        <p><strong>Note:</strong> This does NOT delete your account, only the selected pin. Pin deletions are crowd-sourced — any signed-in user can remove a pin.</p>
     </div>
 
-    <h3>Option 2: Delete Entire Account</h3>
-    <p>To permanently delete your account and all associated data:</p>
+    <h3>Option 2: Delete Your Account (In-App, Recommended)</h3>
+    <p>You can delete your entire account directly from the app:</p>
 
     <ol>
-        <li>Send an email to <a href="mailto:camilo@kyberneticlabs.com">camilo@kyberneticlabs.com</a></li>
-        <li>Use the subject line: <strong>"CCW Map Account Deletion Request"</strong></li>
-        <li>Include the following information:
-            <ul>
-                <li>The email address associated with your CCW Map account</li>
-                <li>Confirmation that you want to permanently delete your account</li>
-            </ul>
-        </li>
+        <li>Open the CCW Map app and make sure you are signed in.</li>
+        <li>Tap the <strong>gear icon</strong> (top-right of the map) to open <strong>Settings</strong>.</li>
+        <li>Tap <strong>Delete Account</strong>.</li>
+        <li>A confirmation dialog will ask you to type <strong>DELETE</strong> (all caps) to proceed — this protects against accidental taps.</li>
+        <li>Tap <strong>Delete</strong>. Your account is removed immediately, you are signed out of all devices, and you are returned to the map as a guest.</li>
+    </ol>
+
+    <p>No email, ticket, or waiting period required. Deletion is instant and irreversible.</p>
+
+    <h3>Option 3: Email Fallback</h3>
+    <p>If you cannot access the app — for example, because you no longer have the installed device or you have forgotten your password and cannot reset it — you can request deletion by email:</p>
+
+    <ol>
+        <li>Email <a href="mailto:camilo@kyberneticlabs.com">camilo@kyberneticlabs.com</a> from the address associated with your CCW Map account.</li>
+        <li>Use the subject line: <strong>"CCW Map Account Deletion Request"</strong>.</li>
+        <li>Include confirmation that you want to permanently delete your account.</li>
     </ol>
 
     <div class="contact-box">
-        <p><strong>Email for Deletion Requests:</strong></p>
+        <p><strong>Email for fallback deletion requests:</strong></p>
         <a href="mailto:camilo@kyberneticlabs.com">camilo@kyberneticlabs.com</a>
     </div>
 
     <hr>
 
-    <h2>Verification Process</h2>
+    <h2>Verification</h2>
 
-    <p>To protect your account security, we will verify your identity:</p>
+    <p>Your identity is verified automatically depending on the path:</p>
 
-    <ol>
-        <li><strong>Email Verification</strong>: You must send the deletion request from the email address associated with your account</li>
-        <li><strong>Confirmation</strong>: We may ask you to confirm your request via a follow-up email</li>
-        <li><strong>Processing Time</strong>: Your data will be deleted within <strong>30 days</strong> of receiving your verified request</li>
-    </ol>
+    <ul>
+        <li><strong>In-app deletion (Option 2):</strong> Your active signed-in session is the proof of identity. The app calls a server-side function that deletes the account associated with your session; no email round-trip is required.</li>
+        <li><strong>Email fallback (Option 3):</strong> The request must come from the email address on the account. We may ask you to confirm via a follow-up email. Processed within <strong>30 days</strong> of receiving your verified request.</li>
+    </ul>
 
     <hr>
 
@@ -184,10 +192,10 @@
     <div class="warning">
         <p>Once your account is deleted:</p>
         <ul>
-            <li>You will be logged out of all devices</li>
-            <li>You cannot sign in with the same email address for 30 days</li>
-            <li>Pins you created will be removed from the map</li>
-            <li>You will receive a confirmation email once deletion is complete</li>
+            <li>You are signed out of all devices.</li>
+            <li>Your authentication record and associated personal data (see "What Gets Deleted" above) are removed from our servers.</li>
+            <li>The pins you created stay on the map (they are community data and are no longer tied to a user identity), but any signed-in user can edit or remove them at any time via crowd-sourced moderation. If you want specific pins gone, remove them <strong>before</strong> deleting your account (Option 1).</li>
+            <li>The email address is released and may be used to sign up for a new account.</li>
         </ul>
     </div>
 
@@ -229,7 +237,7 @@
     <hr>
 
     <p style="text-align: center; color: #666; margin-top: 40px;">
-        <strong>Last Updated:</strong> February 1, 2026
+        <strong>Last Updated:</strong> April 24, 2026
     </p>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -46,6 +46,7 @@
     <p>Collaborative mapping of concealed carry zones</p>
 
     <div class="links">
+        <a href="terms/">Terms of Use</a>
         <a href="privacy-policy.html">Privacy Policy</a>
         <a href="data-deletion.html">Data Deletion</a>
     </div>

--- a/docs/privacy-policy.html
+++ b/docs/privacy-policy.html
@@ -67,8 +67,8 @@
     <h1>Privacy Policy for CCW Map</h1>
 
     <div class="header-info">
-        <p><strong>Effective Date:</strong> February 1, 2026</p>
-        <p><strong>Last Updated:</strong> February 1, 2026</p>
+        <p><strong>Effective Date:</strong> April 24, 2026</p>
+        <p><strong>Last Updated:</strong> April 24, 2026</p>
     </div>
 
     <hr>
@@ -105,6 +105,13 @@
         <li><strong>Restriction Tags</strong>: Information about restriction types for NO_GUN zones</li>
         <li><strong>Metadata</strong>: Timestamps and user IDs associated with pins for accountability</li>
         <li><strong>Note</strong>: All pins are publicly visible to all app users</li>
+    </ul>
+
+    <h3>4. Safety and Moderation</h3>
+    <ul>
+        <li><strong>Pin Reports</strong>: When you report a pin, we store the pin reference, your user ID as reporter, the reason you selected, and any optional note. Reports are visible only to moderators, not to other users.</li>
+        <li><strong>Blocklist</strong>: When you block another user, we store a record linking your user ID (blocker) to theirs (blocked). This record is used to hide the blocked user's pins from your map.</li>
+        <li><strong>Terms Acceptance</strong>: When you accept the Terms of Use, we store your user ID, the version of the terms, and a timestamp. This record demonstrates consent and triggers re-acceptance if the terms materially change.</li>
     </ul>
 
     <hr>

--- a/docs/terms/index.html
+++ b/docs/terms/index.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Terms of Use & Community Guidelines - CCW Map</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            line-height: 1.6;
+            color: #333;
+        }
+        h1 {
+            color: #1a1a1a;
+            border-bottom: 2px solid #0066cc;
+            padding-bottom: 10px;
+        }
+        h2 {
+            color: #0066cc;
+            margin-top: 30px;
+        }
+        h3 {
+            color: #333;
+            margin-top: 20px;
+        }
+        a {
+            color: #0066cc;
+            text-decoration: none;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+        hr {
+            border: none;
+            border-top: 1px solid #ddd;
+            margin: 30px 0;
+        }
+        strong {
+            color: #1a1a1a;
+        }
+        ul, ol {
+            padding-left: 20px;
+        }
+        .header-info {
+            background: #f5f5f5;
+            padding: 15px;
+            border-radius: 5px;
+            margin-bottom: 20px;
+        }
+        .important {
+            background: #fff3cd;
+            border-left: 4px solid #ffc107;
+            padding: 15px;
+            margin: 20px 0;
+        }
+        .danger {
+            background: #f8d7da;
+            border-left: 4px solid #dc3545;
+            padding: 15px;
+            margin: 20px 0;
+        }
+        @media (max-width: 600px) {
+            body {
+                padding: 10px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <h1>Terms of Use & Community Guidelines</h1>
+
+    <div class="header-info">
+        <p><strong>Effective Date:</strong> April 24, 2026</p>
+        <p><strong>Last Updated:</strong> April 24, 2026</p>
+        <p><strong>Version:</strong> 1</p>
+    </div>
+
+    <hr>
+
+    <h2>1. About CCW Map</h2>
+    <p>CCW Map is a mobile application that lets users collaboratively map and share information about concealed carry weapon (CCW) zones. The map is built from user-generated content: any signed-in user may create, update, or remove pins.</p>
+
+    <hr>
+
+    <h2>2. Acceptance of Terms</h2>
+    <p>By installing, opening, or using CCW Map ("the app") you agree to these Terms of Use and the Community Guidelines below. If you do not agree, do not use the app.</p>
+    <p>You also agree to our <a href="../privacy-policy.html">Privacy Policy</a>, which explains what we collect and how we handle it.</p>
+
+    <hr>
+
+    <h2>3. Eligibility</h2>
+    <ul>
+        <li>You must be at least 17 years of age to use CCW Map.</li>
+        <li>You must comply with all applicable federal, state, and local laws.</li>
+        <li>You are responsible for the accuracy of any account information you provide.</li>
+    </ul>
+
+    <hr>
+
+    <h2>4. User-Generated Content</h2>
+    <p>The map is crowd-sourced. When you place, edit, or remove a pin, that change is visible to every other user.</p>
+    <ul>
+        <li>You are solely responsible for the content you submit.</li>
+        <li>You grant CCW Map a non-exclusive, royalty-free license to host, display, and distribute your submitted content within the app and any related services.</li>
+        <li>Pins are public. Do not submit content you would not want every user to see.</li>
+        <li>The map is informational. It is <strong>not</strong> legal advice. Verify any specific location's signage and applicable law before relying on it.</li>
+    </ul>
+
+    <hr>
+
+    <h2>5. Community Guidelines</h2>
+
+    <div class="danger">
+        <p><strong>There is no tolerance for objectionable content or abusive behavior.</strong> Violations may result in content removal and account suspension without prior notice.</p>
+    </div>
+
+    <p>You may not post, submit, or otherwise contribute content that:</p>
+    <ul>
+        <li>Is hateful, harassing, threatening, or discriminatory toward any person or group.</li>
+        <li>Is sexually explicit, gratuitously violent, or otherwise gratuitously offensive.</li>
+        <li>Promotes illegal activity or violates the rights of others.</li>
+        <li>Is intentionally false, misleading, or designed to mislead other users about a location's status.</li>
+        <li>Is spam, an advertisement, a phishing attempt, or otherwise irrelevant to the purpose of mapping CCW zones.</li>
+        <li>Contains personally identifiable information about other people without their consent.</li>
+        <li>Contains malware, exploits, or links intended to harm users or systems.</li>
+    </ul>
+
+    <p>You may not engage in abusive behavior, including but not limited to:</p>
+    <ul>
+        <li>Harassing, threatening, or stalking other users.</li>
+        <li>Impersonating others or misrepresenting your affiliation with any person or organization.</li>
+        <li>Coordinated manipulation of the map (e.g., placing or removing pins en masse to mislead users).</li>
+        <li>Attempting to circumvent suspension by creating new accounts.</li>
+    </ul>
+
+    <hr>
+
+    <h2>6. Reporting and Blocking</h2>
+    <p>To keep the map useful and safe, the app provides two in-app tools that work without filing a support ticket:</p>
+    <ul>
+        <li><strong>Report a pin.</strong> Tap any pin and choose <em>Report</em>. Pick a reason and add an optional note. Reports are queued for moderator review.</li>
+        <li><strong>Block a user.</strong> From a pin's detail dialog you can block its creator. Pins authored by users you have blocked are hidden from your map immediately and stay hidden on your device.</li>
+    </ul>
+
+    <p><strong>Moderation response time.</strong> We commit to reviewing reports of objectionable content or abusive behavior and taking appropriate action <strong>within 24 hours</strong> of receipt. Action may include removing the offending content, suspending the responsible account, or both.</p>
+
+    <hr>
+
+    <h2>7. Account Suspension and Appeals</h2>
+    <p>We may suspend or terminate accounts that violate these Terms or the Community Guidelines. Suspension typically prevents the account from creating, editing, or deleting pins.</p>
+    <p>If you believe your account has been suspended in error, send an appeal to <a href="mailto:camilo@kyberneticlabs.com">camilo@kyberneticlabs.com</a> from the email address on the account. Include a brief description of the situation. We will respond within a reasonable time.</p>
+
+    <hr>
+
+    <h2>8. Account Deletion</h2>
+    <p>You may delete your account at any time from <strong>Settings → Delete Account</strong> inside the app. Deletion removes your authentication record and signs you out of all devices. See the <a href="../data-deletion.html">Data Deletion page</a> for details on what is removed and what may be retained.</p>
+
+    <hr>
+
+    <h2>9. Disclaimer of Warranties</h2>
+    <p>CCW Map is provided <strong>"as is"</strong> and <strong>"as available"</strong> without warranties of any kind, express or implied. We do not warrant that the app will be uninterrupted, error-free, or that the information shown on the map is accurate, complete, or current.</p>
+    <p>Concealed carry laws vary by jurisdiction and change over time. Always verify the legal status of any specific location before carrying. CCW Map is not a substitute for legal advice or for the posted signage and policies of property owners.</p>
+
+    <hr>
+
+    <h2>10. Limitation of Liability</h2>
+    <p>To the maximum extent permitted by law, CCW Map and its developer shall not be liable for any indirect, incidental, consequential, special, or punitive damages, or for any loss of profits, data, or use, arising from or related to your use of the app — including reliance on user-submitted pins.</p>
+
+    <hr>
+
+    <h2>11. Changes to These Terms</h2>
+    <p>We may update these Terms from time to time. If a change is material, we will surface a re-acceptance prompt the next time you open the app and update the version number above. Continued use after a non-material update constitutes acceptance of the revised Terms.</p>
+
+    <hr>
+
+    <h2>12. Contact</h2>
+    <p>Questions about these Terms, the Community Guidelines, or moderation decisions:</p>
+    <ul>
+        <li><strong>Email:</strong> <a href="mailto:camilo@kyberneticlabs.com">camilo@kyberneticlabs.com</a></li>
+        <li><strong>Privacy Policy:</strong> <a href="../privacy-policy.html">View Privacy Policy</a></li>
+        <li><strong>Data Deletion:</strong> <a href="../data-deletion.html">View Data Deletion page</a></li>
+    </ul>
+
+    <hr>
+
+    <p style="text-align: center; color: #666; margin-top: 40px;">
+        <strong>Last Updated:</strong> April 24, 2026
+    </p>
+</body>
+</html>


### PR DESCRIPTION
- docs/terms/index.html (new): Terms of Use + Community Guidelines served at /ccwmap/terms (directory/index.html pattern, matching auth/callback). Concise ToU with a no-tolerance clause for objectionable content + abusive behavior, report-and-block instructions, explicit 24-hour moderation response commitment, appeals email, v1 / effective 2026-04-24. This is the URL the app's EulaModal and LoginScreen link out to — the page was missing until now.

- docs/data-deletion.html: Option 2 rewritten for the v0.4.0 in-app self-service flow (Settings → Delete Account → type DELETE). Email path retained as Option 3 fallback. What-gets- deleted section corrected to match the delete-account Edge Function behavior: auth record, user_agreements, blocked_users cascade-deleted; pins.created_by + pin_reports.reporter_id go to NULL (pins stay on the map as community content).

- docs/index.html: link the new Terms page from the landing.

- docs/privacy-policy.html: disclose the v0.4.0 data categories (pin reports, blocklists, terms-acceptance records). Bump effective + last-updated to 2026-04-24.