### PR TITLE
chore(release): cut v0.6.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.5.1+0
+version: 0.6.0+0
 
 environment:
   sdk: ^3.9.2

--- a/release_notes/whatsnew-en-US
+++ b/release_notes/whatsnew-en-US
@@ -1,3 +1,3 @@
-Reset your password by email if you forget it.
-New Sign Up screen, separate from Sign In.
-Cleaner login screen with quick links to Sign Up and password reset.
+Pins now cluster at low zoom for a cleaner overview.
+Tap any cluster to zoom in and reveal individual pins.
+The map loads only the pins in your current view.


### PR DESCRIPTION
- Bump pubspec version to 0.6.0+0
- Add v0.6.0 release notes (cluster rendering + viewport-based pin loading)